### PR TITLE
port to 1.21

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -83,18 +83,12 @@ publishMods {
 		projectId = "782514"
 		projectSlug = "no-portals" // Required for discord webhook
 		accessToken = providers.environmentVariable("CURSEFORGE_TOKEN")
-		minecraftVersions.add("1.20.3")
-		minecraftVersions.add("1.20.4")
-		minecraftVersions.add("1.20.5")
 		minecraftVersions.add("1.21")
 		requires("fabric-api")
 	}
 	modrinth {
 		projectId = "ZzkyvOit"
 		accessToken = providers.environmentVariable("MODRINTH_TOKEN")
-		minecraftVersions.add("1.20.3")
-		minecraftVersions.add("1.20.4")
-		minecraftVersions.add("1.20.5")
 		minecraftVersions.add("1.21")
 	}
 	github {

--- a/build.gradle
+++ b/build.gradle
@@ -86,6 +86,7 @@ publishMods {
 		minecraftVersions.add("1.20.3")
 		minecraftVersions.add("1.20.4")
 		minecraftVersions.add("1.20.5")
+		minecraftVersions.add("1.21")
 		requires("fabric-api")
 	}
 	modrinth {
@@ -94,6 +95,7 @@ publishMods {
 		minecraftVersions.add("1.20.3")
 		minecraftVersions.add("1.20.4")
 		minecraftVersions.add("1.20.5")
+		minecraftVersions.add("1.21")
 	}
 	github {
 		repository = "kevinthegreat1/NoPortals-Fabric"

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,9 +4,9 @@ org.gradle.parallel = true
 
 # Fabric Properties
 	# check these on https://fabricmc.net/develop
-	minecraft_version = 1.20.5-rc2
-	yarn_mappings = 1.20.5-rc2+build.2
-	loader_version = 0.15.10
+	minecraft_version = 1.21
+	yarn_mappings = 1.21+build.1
+	loader_version = 0.15.11
 
 # Mod Properties
 	mod_version = 1.1.2
@@ -14,6 +14,6 @@ org.gradle.parallel = true
 	archives_base_name = no-portals
 
 # Dependencies
-	fabric_version = 0.97.4+1.20.5
+	fabric_version = 0.100.1+1.21
 	# https://github.com/NucleoidMC/Server-Translations/releases
 	server_translations_version = 2.3.0+1.20.5-rc2

--- a/src/main/java/com/kevinthegreat/noportals/mixin/EndGatewayBlockEntityMixin.java
+++ b/src/main/java/com/kevinthegreat/noportals/mixin/EndGatewayBlockEntityMixin.java
@@ -2,7 +2,7 @@ package com.kevinthegreat.noportals.mixin;
 
 import com.kevinthegreat.noportals.NoPortals;
 import net.minecraft.block.BlockState;
-import net.minecraft.block.entity.EndGatewayBlockEntity;
+import net.minecraft.block.EndGatewayBlock;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.util.math.BlockPos;
@@ -14,20 +14,15 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-@Mixin(EndGatewayBlockEntity.class)
+@Mixin(EndGatewayBlock.class)
 public abstract class EndGatewayBlockEntityMixin {
-    @Shadow
-    private static void startTeleportCooldown(World world, BlockPos pos, BlockState state, EndGatewayBlockEntity blockEntity) {
-    }
-
-    @Inject(method = "tryTeleportingEntity", at = @At(value = "FIELD", target = "Lnet/minecraft/block/entity/EndGatewayBlockEntity;teleportCooldown:I", opcode = Opcodes.PUTFIELD, ordinal = 0, shift = At.Shift.AFTER), cancellable = true)
-    private static void noportals_disableEndGateway(World world, BlockPos pos, BlockState state, Entity entity, EndGatewayBlockEntity blockEntity, CallbackInfo ci) {
+    @Inject(method = "onEntityCollision", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/Entity;tryUsePortal(Lnet/minecraft/block/Portal;Lnet/minecraft/util/math/BlockPos;)V"), cancellable = true)
+    protected void noportals_disableEndGateway(BlockState state, World world, BlockPos pos, Entity entity, CallbackInfo ci) {
         if (NoPortals.getOptions().isEndGatewayDisabled()) {
             if (entity instanceof PlayerEntity player) {
                 NoPortals.sendPortalDisabledMessage(player, NoPortals.MOD_ID + ":disabled.endGateway");
             }
             ci.cancel();
-            startTeleportCooldown(world, pos, state, blockEntity);
         }
     }
 }

--- a/src/main/java/com/kevinthegreat/noportals/mixin/NetherPortalBlockMixin.java
+++ b/src/main/java/com/kevinthegreat/noportals/mixin/NetherPortalBlockMixin.java
@@ -14,7 +14,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(NetherPortalBlock.class)
 public abstract class NetherPortalBlockMixin {
-    @Inject(method = "onEntityCollision", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/Entity;setInNetherPortal(Lnet/minecraft/util/math/BlockPos;)V"), cancellable = true)
+    @Inject(method = "onEntityCollision", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/Entity;tryUsePortal(Lnet/minecraft/block/Portal;Lnet/minecraft/util/math/BlockPos;)V"), cancellable = true)
     private void noportals_disableNetherPortal(BlockState state, World world, BlockPos pos, Entity entity, CallbackInfo ci) {
         if (NoPortals.getOptions().isNetherPortalDisabled()) {
             if (entity instanceof PlayerEntity player) {


### PR DESCRIPTION
A quick port to 1.21. 
It has only received light testing. All three portal types could be disabled and re-enabled.